### PR TITLE
svc_acct was renamed to svc_acct_key

### DIFF
--- a/swagger3.yml
+++ b/swagger3.yml
@@ -26,7 +26,7 @@ components:
       type: object
       properties:
         task_id: {type: string, format: uuid, description: "Optional. If missing or empty string, the server will create a unique ID for your task and return it in the response."}
-        svc_acct: {type: string, format: uuid, description: "Service account used for authentication"}
+        svc_acct_key: {type: string, format: uuid, description: "Service account used for authentication"}
         meta: {type: object, description: "Freeform dictionary. These will be visible in the API. 'shape' key is used for ETA prediction."}
     CreateTaskResponse:
       type: object
@@ -36,7 +36,7 @@ components:
       type: object
       properties:
         task_id: {type: string, format: uuid}
-        svc_acct: {type: string, format: uuid, description: "Service account used for authentication"}
+        svc_acct_key: {type: string, format: uuid, description: "Service account used for authentication"}
         path: {type: string, description: "Dotted string like 'outer.middle.inner'"}
         patch: {$ref: '#/components/schemas/ProgressRow'}
     SetPathResponse:
@@ -54,7 +54,7 @@ components:
       type: object
       properties:
         task_id: {type: string, format: uuid}
-        svc_acct: {type: string, format: uuid, description: "Service account used for authentication"}
+        svc_acct_key: {type: string, format: uuid, description: "Service account used for authentication"}
         active: {type: boolean, description: "Optional. Pass true to 're-activate' i.e. 'un-finish' a task"}
     FinishTaskResponse:
       type: object


### PR DESCRIPTION
In the hand coded lib implementations `svc_acct` param in the json auth body is actually called` svc_acct_key` so im guessing it was renamed at some point. 

Makes the documentation hard to use and make codegen impossible. 